### PR TITLE
Adding  --depth=0 to npm ls and fix maxBuffer errror

### DIFF
--- a/npm-global.js
+++ b/npm-global.js
@@ -116,7 +116,7 @@ var links;
 /* version comparison and install packages. */
 /*------------------------------------------*/
 console.log('Configuring global Node environment...')
-run('npm ls -g --json', function(stdout)
+run('npm ls -g --json --depth=0', function(stdout)
   {
   installed = JSON.parse(stdout).dependencies || {};
   doWhile();


### PR DESCRIPTION
On some systems (tested on Windows 7 x64, node.js version 4.4.5) without --depth=0 flag  we got 'stdout maxBuffer exceeded' error.
Note: there were more than 30 npm packages installed globally in the tested system.
